### PR TITLE
Fix `check_for_panic` to not always return True.

### DIFF
--- a/flagship/helpers/api.py
+++ b/flagship/helpers/api.py
@@ -72,8 +72,8 @@ class ApiManager:
         return campaigns
 
     def check_for_panic(self, json_response):
-        if json_response is not None and 'panic' in json_response:
-            return True
+        if json_response is not None:
+            return json_response.get("panic", False)
         return False
 
     def activate_modification(self, visitor_id, variation_group_id, variation_id):


### PR DESCRIPTION
We've been having issue with Flagship on our backend where after every `synchronize_modifications` everything was marked to be in `panic_mode` and thus, any modification/decisions would not check against the server, but instead revert to the specified local default. 

Examining the API response further, I found that the call to the `campagins` endpoint looks like this. 
```
{
    "visitorId": "customer-1",
    "campaigns": [...]
    "panic": false
}
```
After locating the `check_for_panic` function, it seems the logic just check if the `panic` key is present, but not what the value is set too, i.e
```
def check_for_panic(self, json_response):
    if json_response is not None and 'panic' in json_response:
        return True
    return False
```

I'm not sure if something has changed behind the scenes with the API (i.e the `panic` key was previously omitted if `false`) but I believe this is the crux of the issue. 


Full logs (with sensitive info retracted)
```
INFO 2021-10-26T09:36:14+0000 module=adapter lineno=45 Creating flagship visitor with context {'context': {'customer_id': '1'}, 'visitor_id': 'customer-1'}
26-10-2021 09:36:14 - [Flagship] : Started
DEBUG 2021-10-26T09:36:14+0000 module=handler lineno=32 26-10-2021 09:36:14 - [Flagship] : Started
26-10-2021 09:36:14 - [Flagship] : [update_context] : Visitor 'None' Context = {'fs_all_users': '', 'fs_users': '', 'sdk_deviceLanguage': '', 'sdk_deviceType': '', 'sdk_deviceModel': '', 'sdk_city': '', 'sdk_region': '', 'sdk_country': '', 'sdk_lat': '', 'sdk_long': '', 'sdk_ip': '', 'sdk_osName': '', 'sdk_osVersion': '', 'sdk_apiLevel': '', 'sdk_pythonVersion': '', 'sdk_carrierName': '', 'sdk_devMode': '', 'sdk_firstTimeInit': '', 'sdk_internetConnection': '', 'sdk_versionName': '', 'sdk_versionCode': '', 'sdk_fsVersion': '', 'sdk_interfaceName': '', 'customer_id': '1'}.
DEBUG 2021-10-26T09:36:14+0000 module=handler lineno=32 26-10-2021 09:36:14 - [Flagship] : [update_context] : Visitor 'None' Context = {'fs_all_users': '', 'fs_users': '', 'sdk_deviceLanguage': '', 'sdk_deviceType': '', 'sdk_deviceModel': '', 'sdk_city': '', 'sdk_region': '', 'sdk_country': '', 'sdk_lat': '', 'sdk_long': '', 'sdk_ip': '', 'sdk_osName': '', 'sdk_osVersion': '', 'sdk_apiLevel': '', 'sdk_pythonVersion': '', 'sdk_carrierName': '', 'sdk_devMode': '', 'sdk_firstTimeInit': '', 'sdk_internetConnection': '', 'sdk_versionName': '', 'sdk_versionCode': '', 'sdk_fsVersion': '', 'sdk_interfaceName': '', 'customer_id': '1'}.
26-10-2021 09:36:14 - [Flagship] : Visitor 'customer-1' created. Context : {'fs_all_users': '', 'fs_users': '', 'sdk_deviceLanguage': '', 'sdk_deviceType': '', 'sdk_deviceModel': '', 'sdk_city': '', 'sdk_region': '', 'sdk_country': '', 'sdk_lat': '', 'sdk_long': '', 'sdk_ip': '', 'sdk_osName': '', 'sdk_osVersion': '', 'sdk_apiLevel': '', 'sdk_pythonVersion': '', 'sdk_carrierName': '', 'sdk_devMode': '', 'sdk_firstTimeInit': '', 'sdk_internetConnection': '', 'sdk_versionName': '', 'sdk_versionCode': '', 'sdk_fsVersion': '', 'sdk_interfaceName': '', 'customer_id': '1'}
DEBUG 2021-10-26T09:36:14+0000 module=handler lineno=32 26-10-2021 09:36:14 - [Flagship] : Visitor 'customer-1' created. Context : {'fs_all_users': '', 'fs_users': '', 'sdk_deviceLanguage': '', 'sdk_deviceType': '', 'sdk_deviceModel': '', 'sdk_city': '', 'sdk_region': '', 'sdk_country': '', 'sdk_lat': '', 'sdk_long': '', 'sdk_ip': '', 'sdk_osName': '', 'sdk_osVersion': '', 'sdk_apiLevel': '', 'sdk_pythonVersion': '', 'sdk_carrierName': '', 'sdk_devMode': '', 'sdk_firstTimeInit': '', 'sdk_internetConnection': '', 'sdk_versionName': '', 'sdk_versionCode': '', 'sdk_fsVersion': '', 'sdk_interfaceName': '', 'customer_id': '1'}
26-10-2021 09:36:14 - [Flagship] : [Request][200] https://decision.flagship.io/v2/FLAGSHIP_ENV_ID/campaigns/?exposeAllKeys=true&sendContextEvent=false - payload: {"visitorId": "customer-1", "trigger_hit": false, "context": {"sdk_deviceLanguage": "", "sdk_deviceType": "", "sdk_deviceModel": "", "sdk_city": "", "sdk_region": "", "sdk_country": "", "sdk_lat": "", "sdk_long": "", "sdk_ip": "", "sdk_osName": "", "sdk_osVersion": "", "sdk_apiLevel": "", "sdk_pythonVersion": "", "sdk_carrierName": "", "sdk_devMode": "", "sdk_firstTimeInit": "", "sdk_internetConnection": "", "sdk_versionName": "", "sdk_versionCode": "", "sdk_fsVersion": "", "sdk_interfaceName": "", "customer_id": "1"}} - response: b'{"visitorId": "customer-1", "campaigns": [{"id": "1", "variation": {"id": "2", "modifications": {"type": "FLAG", "value": {"someFlag": true}}}, "variationGroupId": "3"}], "panic": false}'
DEBUG 2021-10-26T09:36:14+0000 module=handler lineno=32 26-10-2021 09:36:14 - [Flagship] : [Request][200] https://decision.flagship.io/v2/FLAGSHIP_ENV_ID/campaigns/?exposeAllKeys=true&sendContextEvent=false - payload: {"visitorId": "customer-1", "trigger_hit": false, "context": {"sdk_deviceLanguage": "", "sdk_deviceType": "", "sdk_deviceModel": "", "sdk_city": "", "sdk_region": "", "sdk_country": "", "sdk_lat": "", "sdk_long": "", "sdk_ip": "", "sdk_osName": "", "sdk_osVersion": "", "sdk_apiLevel": "", "sdk_pythonVersion": "", "sdk_carrierName": "", "sdk_devMode": "", "sdk_firstTimeInit": "", "sdk_internetConnection": "", "sdk_versionName": "", "sdk_versionCode": "", "sdk_fsVersion": "", "sdk_interfaceName": "", "customer_id": "1"}} - response: b'{"visitorId": "customer-1", "campaigns": [{"id": "1", "variation": {"id": "2", "modifications": {"type": "FLAG", "value": {"someFlag": true}}}, "variationGroupId": "3"}], "panic": false}'
26-10-2021 09:36:14 - [Flagship] : [synchronize_modifications] Panic mode is enabled.
DEBUG 2021-10-26T09:36:14+0000 module=handler lineno=32 26-10-2021 09:36:14 - [Flagship] : [synchronize_modifications] Panic mode is enabled.
26-10-2021 09:36:14 - [Flagship] : [synchronize_modifications] not possible while panic mode is enabled.
DEBUG 2021-10-26T09:36:14+0000 module=handler lineno=32 26-10-2021 09:36:14 - [Flagship] : [synchronize_modifications] not possible while panic mode is enabled.
26-10-2021 09:36:14 - [Flagship] : [get_modification] for key 'someFlag' not possible while panic mode is enabled.
DEBUG 2021-10-26T09:36:14+0000 module=handler lineno=32 26-10-2021 09:36:14 - [Flagship] : [get_modification] for key 'someFlag' not possible while panic mode is enabled.
INFO 2021-10-26T09:36:14+0000 module=adapter lineno=49 Received feature flag False for context {'context': {'customer_id': '1'}, 'visitor_id': 'customer-1'}
```