### PR TITLE
fix: remove pytest from dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.venv/
 venv
 venv2.7
 venv3.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,31 +1,3 @@
 [build-system]
 requires = ["setuptools>=44.1.0"]
 build-backend = "setuptools.build_meta"
-#
-#[project]
-#name = "flagship"
-#version = "2.1.4"
-#authors = [
-#  { name="Flagship Team", email="support@flagship.io" },
-#]
-#description = "Flagship Python SDKe"
-#readme = "README.md"
-#license = { file="LICENSE" }
-#requires-python = ">=2.7"
-#classifiers = [
-#    "Programming Language :: Python :: 3",
-#    "Operating System :: OS Independent",
-#]
-#packages = ["flagship"]
-#dependencies = [
-#    "requests==2.27.1",
-#    "pytest==4.6.11",
-#    "typing==3.7.4.3",
-#    "six==1.16.0",
-#    "enum34~=1.1.10",
-#    "responses==0.17.0",
-#]
-#
-#[project.urls]
-#"Documentation" = "https://docs.developers.flagship.io/docs/python-v2-1"
-#"Sources" = "https://github.com/abtasty/flagship-python-sdk"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests==2.27.1
-pytest==4.6.11
 typing==3.7.4.3
 six==1.16.0
 enum34~=1.1.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ package_dir =
 
 install_requires =
     requests ==2.27.1
-    pytest ==4.6.11
     typing ==3.7.4.3
     six ==1.16.0
     enum34 ~=1.1.10


### PR DESCRIPTION
Hello there 👋🏻 

`pytest` as a pinned dependency to an old version may cause unsolvable version conflict, specifically when using `poetry` on your project.

This PR solves this by removing pytest from install dependencies and requirements.

Solves https://github.com/flagship-io/flagship-python-sdk/issues/17

Thank you in advance for you consideration on integrating this PR :)

